### PR TITLE
14335 publisher fixes

### DIFF
--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -180,7 +180,7 @@ class UnrealSessionCollector(HookBaseClass):
                     parent_item,
                     # :class:`Name` instances, we cast them to strings otherwise
                     # string operations fail down the line..
-                    "%s" % asset.object_path,
+                    "%s" % unreal_sg.object_path(asset),
                     "%s" % asset.asset_class,
                     "%s" % asset.asset_name,
                 )
@@ -255,7 +255,8 @@ class UnrealSessionCollector(HookBaseClass):
         :param sequence_edits: A dictionary with  :class:`unreal.LevelSequence as keys and
                                               lists of :class:`SequenceEdit` as values.
         """
-        level_sequence = unreal.load_asset(asset.object_path)
+        unreal_sg = sgtk.platform.current_engine().unreal_sg_engine
+        level_sequence = unreal.load_asset(unreal_sg.object_path(asset))
         for edits_path in self.get_all_paths_from_sequence(level_sequence, sequence_edits):
             # Reverse the path to have it from top master sequence to the shot.
             edits_path.reverse()
@@ -284,12 +285,13 @@ class UnrealSessionCollector(HookBaseClass):
                   lists of :class:`SequenceEdit`.
         """
         sequence_edits = defaultdict(list)
+        unreal_sg = sgtk.platform.current_engine().unreal_sg_engine
 
         asset_helper = unreal.AssetRegistryHelpers.get_asset_registry()
         # Retrieve all Level Sequence assets
         all_level_sequences = asset_helper.get_assets_by_class("LevelSequence")
         for lvseq_asset in all_level_sequences:
-            lvseq = unreal.load_asset(lvseq_asset.object_path, unreal.LevelSequence)
+            lvseq = unreal.load_asset(unreal_sg.object_path(lvseq_asset), unreal.LevelSequence)
             # Check shots
             for track in lvseq.find_master_tracks_by_type(unreal.MovieSceneCinematicShotTrack):
                 for section in track.get_sections():

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -172,7 +172,6 @@ class UnrealSessionCollector(HookBaseClass):
         # Iterate through the selected assets and get their info and add them as items to be published
         for asset in unreal_sg.selected_assets:
             if asset.asset_class_path.asset_name == "LevelSequence":
-                self.logger.warning("%s.%s"% (asset.asset_class_path.package_name, asset.asset_class_path.asset_name))
                 if sequence_edits is None:
                     sequence_edits = self.retrieve_sequence_edits()
                 self.collect_level_sequence(parent_item, asset, sequence_edits)

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -181,7 +181,7 @@ class UnrealSessionCollector(HookBaseClass):
                     # :class:`Name` instances, we cast them to strings otherwise
                     # string operations fail down the line..
                     "%s" % unreal_sg.object_path(asset),
-                    "%s" % asset.asset_class,
+                    "%s" % asset.asset_class_path.asset_name,
                     "%s" % asset.asset_name,
                 )
 

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -172,8 +172,9 @@ class UnrealSessionCollector(HookBaseClass):
         # Iterate through the selected assets and get their info and add them as items to be published
         for asset in unreal_sg.selected_assets:
             if asset.asset_class_path.asset_name == "LevelSequence":
+                self.logger.warning("%s.%s"% (asset.asset_class_path.package_name, asset.asset_class_path.asset_name))
                 if sequence_edits is None:
-                    sequence_edits = self.retrieve_sequence_edits(asset.asset_class_path)
+                    sequence_edits = self.retrieve_sequence_edits()
                 self.collect_level_sequence(parent_item, asset, sequence_edits)
             else:
                 self.create_asset_item(
@@ -276,21 +277,20 @@ class UnrealSessionCollector(HookBaseClass):
             # publishing.
             item.properties["edits_path"] = edits_path
 
-    def retrieve_sequence_edits(self, class_path):
+    def retrieve_sequence_edits(self):
         """
         Build a dictionary for all Level Sequences where keys are Level Sequences
         and values the list of edits they are in.
 
-        :param class_path: A :class:`TopLevelAssetPath`.
         :returns: A dictionary of :class:`unreal.LevelSequence` where values are
                   lists of :class:`SequenceEdit`.
         """
         sequence_edits = defaultdict(list)
         unreal_sg = sgtk.platform.current_engine().unreal_sg_engine
-
+        lclass = unreal.TopLevelAssetPath("/Script/LevelSequence", "LevelSequence")
         asset_helper = unreal.AssetRegistryHelpers.get_asset_registry()
         # Retrieve all Level Sequence assets
-        all_level_sequences = asset_helper.get_assets_by_class(class_path)
+        all_level_sequences = asset_helper.get_assets_by_class(lclass)
         for lvseq_asset in all_level_sequences:
             lvseq = unreal.load_asset(unreal_sg.object_path(lvseq_asset), unreal.LevelSequence)
             # Check shots

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -287,10 +287,10 @@ class UnrealSessionCollector(HookBaseClass):
         """
         sequence_edits = defaultdict(list)
         unreal_sg = sgtk.platform.current_engine().unreal_sg_engine
-        lclass = unreal.TopLevelAssetPath("/Script/LevelSequence", "LevelSequence")
+        level_sequence_class = unreal.TopLevelAssetPath("/Script/LevelSequence", "LevelSequence")
         asset_helper = unreal.AssetRegistryHelpers.get_asset_registry()
         # Retrieve all Level Sequence assets
-        all_level_sequences = asset_helper.get_assets_by_class(lclass)
+        all_level_sequences = asset_helper.get_assets_by_class(level_sequence_class)
         for lvseq_asset in all_level_sequences:
             lvseq = unreal.load_asset(unreal_sg.object_path(lvseq_asset), unreal.LevelSequence)
             # Check shots

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -171,9 +171,9 @@ class UnrealSessionCollector(HookBaseClass):
         sequence_edits = None
         # Iterate through the selected assets and get their info and add them as items to be published
         for asset in unreal_sg.selected_assets:
-            if asset.asset_class == "LevelSequence":
+            if asset.asset_class_path.asset_name == "LevelSequence":
                 if sequence_edits is None:
-                    sequence_edits = self.retrieve_sequence_edits()
+                    sequence_edits = self.retrieve_sequence_edits(asset.asset_class_path)
                 self.collect_level_sequence(parent_item, asset, sequence_edits)
             else:
                 self.create_asset_item(
@@ -276,11 +276,12 @@ class UnrealSessionCollector(HookBaseClass):
             # publishing.
             item.properties["edits_path"] = edits_path
 
-    def retrieve_sequence_edits(self):
+    def retrieve_sequence_edits(self, class_path):
         """
         Build a dictionary for all Level Sequences where keys are Level Sequences
         and values the list of edits they are in.
 
+        :param class_path: A :class:`TopLevelAssetPath`.
         :returns: A dictionary of :class:`unreal.LevelSequence` where values are
                   lists of :class:`SequenceEdit`.
         """
@@ -289,7 +290,7 @@ class UnrealSessionCollector(HookBaseClass):
 
         asset_helper = unreal.AssetRegistryHelpers.get_asset_registry()
         # Retrieve all Level Sequence assets
-        all_level_sequences = asset_helper.get_assets_by_class("LevelSequence")
+        all_level_sequences = asset_helper.get_assets_by_class(class_path)
         for lvseq_asset in all_level_sequences:
             lvseq = unreal.load_asset(unreal_sg.object_path(lvseq_asset), unreal.LevelSequence)
             # Check shots

--- a/python/tk_unreal/unreal_sg_engine.py
+++ b/python/tk_unreal/unreal_sg_engine.py
@@ -247,7 +247,7 @@ class ShotgunEngineWrapper(UESGEngine):
         # UE 5.1
         if hasattr(asset_data, "object_path"):
             return asset_data.object_path
-        return "%s.%s" (asset_data.package_name, asset_data.asset_name)
+        return "%s.%s" % (asset_data.package_name, asset_data.asset_name)
 
     """
     Menu generation functionality for Unreal (based on the 3ds max Menu Generation implementation)

--- a/python/tk_unreal/unreal_sg_engine.py
+++ b/python/tk_unreal/unreal_sg_engine.py
@@ -148,7 +148,7 @@ class ShotgunEngineWrapper(UESGEngine):
             # Asset must be loaded to read the metadata from item
             # Note that right-clicking on an asset in the Unreal Content Browser already loads item
             # But a load could be triggered if the context is from a selected actor
-            loaded_asset = unreal.EditorAssetLibrary.load_asset(selected_asset.object_path)
+            loaded_asset = unreal.EditorAssetLibrary.load_asset(self.object_path(selected_asset))
         elif selected_actor:
             # Get the asset that is associated with the selected actor
             assets = self.get_referenced_assets(selected_actor)
@@ -234,6 +234,20 @@ class ShotgunEngineWrapper(UESGEngine):
             engine.destroy()
             QtWidgets.QApplication.instance().quit()
             QtWidgets.QApplication.processEvents()
+
+    @staticmethod
+    def object_path(asset_data):
+        """
+        Return the object path for the given asset_data.
+
+        :param asset_data: A :class:`AssetData` instance.
+        :returns: A string.
+        """
+        # The attribute is not available anymore from
+        # UE 5.1
+        if hasattr(asset_data, "object_path"):
+            return asset_data.object_path
+        return "%s.%s" (asset_data.package_name, asset_data.asset_name)
 
     """
     Menu generation functionality for Unreal (based on the 3ds max Menu Generation implementation)


### PR DESCRIPTION
Fixes for UE api changes:
- Introduced a `object_path` helper to retrieve the object path of `AssetData` since the property was removed.
- Fixed `get_assets_by_class` not accepting a class name anymore but requiring a root path.
- Fixed `asset_class` being deprecated and returning `None`.